### PR TITLE
AB#131261 remove SecurityCodeScan.VS2019

### DIFF
--- a/Nfield.Quota/Nfield.Quota.csproj
+++ b/Nfield.Quota/Nfield.Quota.csproj
@@ -19,7 +19,7 @@
   </PropertyGroup>
 
   <Import Project="..\CodeAnalysis\NipoSoftware.DefaultProjectRules.targets" />
-  
+
   <ItemGroup>
     <PackageReference Include="FluentValidation" Version="10.2.3" />
     <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="5.0.3">
@@ -27,10 +27,6 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
-    <PackageReference Include="SecurityCodeScan.VS2019" Version="5.0.0">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
     <PackageReference Include="SonarAnalyzer.CSharp" Version="8.19.0.28253">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/version.txt
+++ b/version.txt
@@ -1,5 +1,5 @@
-# Versioning of the NuGet package should be done in the following format: 
-# {major}.{minor}.{buildId}{suffix} where suffix should be either 
+# Versioning of the NuGet package should be done in the following format:
+# {major}.{minor}.{buildId}{suffix} where suffix should be either
 # "-alpha", "-beta" or "" (empty) for respectively non-master-branches, master-branches
 # and release-versions (which is triggered once a release is published)
-5.0.{buildId}{suffix}
+5.1.{buildId}{suffix}


### PR DESCRIPTION
[AB#131261](https://dev.azure.com/niposoftware/15ce0e91-931d-4fbf-9169-8c3dde412b54/_workitems/edit/131261)

Related PRs:

https://github.com/NIPOSoftwareBV/Nfield-SDK/pull/444
https://github.com/NIPOSoftwareBV/Nfield.Quota/pull/119
https://github.com/NIPOSoftwareBV/nfield-odinparser/pull/276/
https://github.com/NIPOSoftwareBV/nfield-remote-mediator/pull/40/
https://github.com/NIPOSoftwareBV/nfield-tenant-signup/pull/358/
https://github.com/NIPOSoftwareBV/nfield-survey-fieldwork-package/pull/42/
https://github.com/NIPOSoftwareBV/project-glu-api/pull/5431/
https://github.com/NIPOSoftwareBV/nfield-identity/pull/1024/
https://github.com/NIPOSoftwareBV/nfield-script-analyzer/pull/239/
https://github.com/NIPOSoftwareBV/nfield-interviewing/pull/3910/
https://github.com/NIPOSoftwareBV/Nfield-Cati/pull/2134/
https://github.com/NIPOSoftwareBV/nfield-storage/pull/370/
https://github.com/NIPOSoftwareBV/nfield-quota-evaluation/pull/11/
https://github.com/NIPOSoftwareBV/nfield-source/pull/8538/
https://github.com/NIPOSoftwareBV/nfield-nativeengine/pull/149/
https://github.com/NIPOSoftwareBV/nfield-interviewengine/pull/742/
https://github.com/NIPOSoftwareBV/Nfield-Reporting/pull/2425/
https://github.com/NIPOSoftwareBV/nfield-interviewing-contracts/pull/40/
https://github.com/NIPOSoftwareBV/nfield-reporting-events/pull/124/
https://github.com/NIPOSoftwareBV/nfield-permissions/pull/167/
https://github.com/NIPOSoftwareBV/Nfield-Activities/pull/54/
https://github.com/NIPOSoftwareBV/nfield-events/pull/83
https://github.com/NIPOSoftwareBV/nfield-public-api/pull/163

To avoid building packages twice. I've specified the versions that the referenced packages will have once they go to master.
