### PR TITLE
Nfield # DevOps Service Connection

### DIFF
--- a/pipelines/build.yml
+++ b/pipelines/build.yml
@@ -17,7 +17,7 @@ resources:
     - repository: NfieldTools
       type: github
       name: NIPOSoftwareBV/Nfield-Tools
-      endpoint: NfieldToolsRepository
+      endpoint: Nfield # DevOps Service Connection
       ref: # Defaults to master, to build with another version specify the ref here (e.g. 'refs/tags/2019-q1s01') If you want to build from a specific commit, first create a tag pointing to that commit, then pin to that tag.
 
 

--- a/pipelines/deploy-nuget.yml
+++ b/pipelines/deploy-nuget.yml
@@ -22,7 +22,7 @@ resources:
     - repository: NfieldTools
       type: github
       name: NIPOSoftwareBV/Nfield-Tools
-      endpoint: NfieldToolsRepository
+      endpoint: Nfield # DevOps Service Connection
       ref: yellow/yml2nfieldtools # Defaults to master, to build with another version specify the ref here (e.g. 'refs/tags/2019-q1s01') If you want to build from a specific commit, first create a tag pointing to that commit, then pin to that tag.
 
 


### PR DESCRIPTION
**Related PRs:**
https://github.com/NIPOSoftwareBV/nfield-source/pull/8599
https://github.com/NIPOSoftwareBV/Nfield-SDK/pull/451
https://github.com/NIPOSoftwareBV/Nfield-Tools/pull/1166
https://github.com/NIPOSoftwareBV/nfield-public-api/pull/168

**To change:**
Use always Nfield a GitHub-InstallationToken
NfieldToolsRepository to Nfield to be aligned with the pipeline triggers that are using Nfield, NfieldToolsRepository is not needed anymore

**New for specific cases:**
NipoGithubDeployment PAT to be used by DevOps GitHub[...]@1 tasks that only allow oauth and PAT Service Connections. This Github PAT has been created with the shared account nipodeployment@ktglbuc.onmicrosoft.com (See Nfield Passwords - powerful accounts.kdbx)

**Next PBI:**
Cleanup - Delete all non used Connections and keep only:
- Nfield (Pippeline triggers and repo checkouts)
- NipoGithubDeployment (to use with)

Service connections
|Creator							|Email							|Service connection Name	| Type - User									|
|-									|-								|-							| -   											|
|Pilar Rodriguez Cabrero			|p.rodriguez.cabrero@nipo.com	|NfieldToolsRepository		|oauth - unknown								|
|									|								|pilarodriguez				|oauth - unknown								|
|									|								|test						|oauth - unknown								|
|									|p.rodriguez.cabrero@kantar.com	|github.com_sdk				|oauth - unknown								|
|Eva del Nuevo						|e.del.nuevo.munoz@nipo.com		|niposoftware-github		|oauth - unknown								|
|									|								|GitHub connection 1		|oauth - unknown								|
|Jouke van der Maas					|j.maas@nipo.com				|github.com_hnuguse			|oauth - User unknown							|
|									|j.maas@kantar.com				|Nfield						|azure pipelines app							|
|Henok Nuguse						|h.nuguse@nipo.com				|Nfield						|azure pipelines app							|
|									|								|hnuguse					|oauth - unknown								|
|k.efishev							|k.efishev@kantar.com			|kefishev					|oauth - unknown								|
|Neil Boyd							|n.boyd@kantar.com				|GitHub connection 17		|oauth - unknown								|
|									|n.boyd@niposoftware.com		|github.com_nipodeployment	|oauth - unknown								|
|Daniel Quilón						|d.quilon@kantar.com			|Nfield (1)					|azure pipelines app							|
|g.kappen							|g.kappen@niposoftware.com		|GitHub as gkappen			|oauth - unknown								|
|h.kraakman							|h.kraakman@niposoftware.com	|GitHub connection HK		|PAT - unknown									|
|Alberto.Belver						|Alberto.Belver@kantar.com		|github.com_AlbertoBelver	|oauth - unknown								|
|Alberto.Belver						|Alberto.Belver@kantar.com		|NipoGithubDeployment	    |PAT - nipodeployment@ktglbuc.onmicrosoft.com	|


Service connections usage
|Service connection Name	| Used in NIPOSoftwareBV code	| Used in DevOps Trigges			|
|-							|-       						|-									|
|NfieldToolsRepository		| Many pipelines  				|?									|
|pilarodriguez				| No							|?									|
|test						| N/A 							|?									|
|github.com_sdk				| No							|?									|
|niposoftware-github		| No							|?									|
|GitHub connection 1		| No							|?									|
|github.com_hnuguse			| No							|?									|
|Nfield						| Not in pipelines				|Yes but we don't know witch Nfield	|
|Nfield						| Not in pipelines				|Yes but we don't know witch Nfield	|
|hnuguse					| No							|?									|
|kefishev					| No							|?									|
|GitHub connection 17		| No							|?									|
|github.com_nipodeployment	| No							|?									|
|Nfield (1)					| No							|?									|
|GitHub as gkappen			| No							|?									|
|GitHub connection HK		| No							|?									|
|github.com_AlbertoBelver	| No							|?									|
|NipoGithubDeployment	    | SDK and Quota pipelines		|?									|

---

> team(s) or team member(s) automatically mentioned by [CodeGurusBot](https://github.com/NIPOSoftwareBV/Nfield-Documentation/blob/master/Agreements/codegurus.md). If you want to review this PR, please self-request a review.

@NIPOSoftwareBV/team-yellow